### PR TITLE
Proposal - NEXT_KAKAO_MAP_URL이 runtime에서 없을 경우 에러나도록 변경

### DIFF
--- a/front/components/common/KakaoMapScript.tsx
+++ b/front/components/common/KakaoMapScript.tsx
@@ -1,0 +1,20 @@
+import config from '../../config/test-config';
+
+interface KakaoScriptProps {}
+
+const KakaoScript = (props: KakaoScriptProps) => {
+  const kakaoMapUrl = config.NEXT_KAKAO_MAP_URL;
+  if (kakaoMapUrl.length > 0) {
+    return (
+      <>
+          <script type="text/javascript" src={kakaoMapUrl}></script>
+      </>
+    )
+  }
+  console.error("NEXT_KAKAO_MAP_URL is not exist on process environment");
+  return (
+      <></>
+  )
+}
+
+export default KakaoScript;

--- a/front/components/common/Layout.tsx
+++ b/front/components/common/Layout.tsx
@@ -1,17 +1,16 @@
 import Head from 'next/head';
 import styled from 'styled-components';
+import KakaoScript from './KakaoMapScript';
 
 interface LayoutProps {
   children: any;
 }
 
-const kakaoMapUrl = process.env.NEXT_KAKAO_MAP_URL;
-
 const Layout = ({ children }: LayoutProps) => {
   return (
     <>
       <Head>
-        <script type="text/javascript" src={kakaoMapUrl}></script>
+        <KakaoScript />
       </Head>
       <Wrapper>{children}</Wrapper>
     </>

--- a/front/config/test-config.ts
+++ b/front/config/test-config.ts
@@ -1,0 +1,5 @@
+const config = {
+    NEXT_KAKAO_MAP_URL: process.env.NEXT_KAKAO_MAP_URL || "",
+};
+
+export default config;

--- a/front/next.config.js
+++ b/front/next.config.js
@@ -5,9 +5,9 @@ module.exports = {
   reactStrictMode: true,
 };
 
-['NEXT_KAKAO_MAP_URL'].forEach((key) => {
-  if (!_.has(process.env, key)) {
-    console.error(`${key} is not exist on process environment`);
-    process.exit(1);
-  }
-});
+// ['NEXT_KAKAO_MAP_URL'].forEach((key) => {
+//   if (!_.has(process.env, key)) {
+//     console.error(`${key} is not exist on process environment`);
+//     process.exit(1);
+//   }
+// });

--- a/front/pages/index.tsx
+++ b/front/pages/index.tsx
@@ -1,15 +1,14 @@
 import type { NextPage } from "next";
 import Head from "next/head";
-
 import Home from "../components/Home";
+import KakaoScript from "../components/common/KakaoMapScript";
 
-const kakaoMapUrl = process.env.NEXT_KAKAO_MAP_URL;
 
 const HomePage: NextPage = () => {
   return (
     <>
       <Head>
-        <script type="text/javascript" src={kakaoMapUrl}></script>
+        <KakaoScript />
       </Head>
       <Home />
     </>

--- a/front/state/action-creators/index.ts
+++ b/front/state/action-creators/index.ts
@@ -14,7 +14,7 @@ export const userSignup = (user: User, callback: () => void) => {
       dispatch({ type: ActionType.USER_SIGNUP_SUCCESS });
       callback();
     } catch (error) {
-      dispatch({ type: ActionType.USER_SIGNUP_ERROR, payload: error });
+      dispatch({ type: ActionType.USER_SIGNUP_ERROR, payload: `${error}` });
     }
   };
 };
@@ -28,7 +28,7 @@ export const userLogin = (user: User, callBack: () => void) => {
       dispatch({ type: ActionType.USER_LOGIN_SUCCESS });
       callBack();
     } catch (error) {
-      dispatch({ type: ActionType.USER_LOGIN_ERROR, payload: error });
+      dispatch({ type: ActionType.USER_LOGIN_ERROR, payload: `${error}` });
     }
   };
 };
@@ -41,7 +41,7 @@ export const getUserLocation = () => {
       const position = await mockApi.getLocation();
       dispatch({ type: ActionType.GET_USER_LOCATION_SUCCESS, payload: position });
     } catch (error) {
-      dispatch({ type: ActionType.GET_USER_LOCATION_ERROR, payload: error });
+      dispatch({ type: ActionType.GET_USER_LOCATION_ERROR, payload: `${error}` });
     }
   };
 };

--- a/front/state/store.ts
+++ b/front/state/store.ts
@@ -2,6 +2,6 @@ import { createStore, applyMiddleware, compose } from "redux";
 import thunk from "redux-thunk";
 import reducers from "./reducers";
 
-const composeEnhancers = (process.env.NODE_ENV === "development" && typeof window !== "undefined" && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) || compose;
+const composeEnhancers = (process.env.NODE_ENV === "development" && typeof window !== "undefined" && (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) || compose;
 
 export const store = createStore(reducers, {}, composeEnhancers(applyMiddleware(thunk)));


### PR DESCRIPTION
## 제안
개인적인 의견으로는 환경 변수는 말 그대로 실행되는 환경의 의존성이라고 생각해서, 빌드시에는 깨지지 않으면 좋겠습니다.
아마도 yarn dev 에서도 NEXT_KAKAO_MAP_URL 환경변수가 없으면 실패하게 하려고 의도하신 것 같은데, yarn build에서도 똑같이 실패하게 되어서, `front/config/test-config.ts` 에서 제안드리는 것처럼 환경변수를 변수에 매핑해서 사용하면 좋을 것 같습니다.

## 작업 내용
- NEXT_KAKAO_MAP_URL가 없어도 `yarn build` 에서는 안깨지도록 수정 
  - env에서 읽되, 없으면 빈 스트링 사용하도록
  - `yarn dev` 하면 런타임에서 고장나도록
  - `NEXT_KAKAO_MAP_URL=xxxx yarn dev` 시에는 정상적으로 작동하도록
- 다른 빌드 깨지는 내용 수정
  - 위 내용 해결하니 다른 부분에서 타입 에러가 깨지는 부분이 있어서, yarn build 테스트를 위해 임의로 수정하였습니다. 무시해주셔도 되요!
  - `front/state/action-creators/index.ts`, `front/state/store.ts` 에서 임시로 몇가지 수정하였습니다.