### PR TITLE
[BE] feat-BLOCK-1: SignUp에 interests 추가

### DIFF
--- a/front/_generated/UserProtocol_pb.d.ts
+++ b/front/_generated/UserProtocol_pb.d.ts
@@ -87,6 +87,11 @@ export class SignUpRequest extends jspb.Message {
   getBirthday(): string;
   setBirthday(value: string): void;
 
+  clearInteresthashtagsList(): void;
+  getInteresthashtagsList(): Array<string>;
+  setInteresthashtagsList(value: Array<string>): void;
+  addInteresthashtags(value: string, index?: number): string;
+
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): SignUpRequest.AsObject;
   static toObject(includeInstance: boolean, msg: SignUpRequest): SignUpRequest.AsObject;
@@ -105,6 +110,7 @@ export namespace SignUpRequest {
     gender: SignUpRequest.GenderMap[keyof SignUpRequest.GenderMap],
     avatar: string,
     birthday: string,
+    interesthashtagsList: Array<string>,
   }
 
   export interface GenderMap {

--- a/front/_generated/UserProtocol_pb.js
+++ b/front/_generated/UserProtocol_pb.js
@@ -75,7 +75,7 @@ if (goog.DEBUG && !COMPILED) {
  * @constructor
  */
 proto.SignUpRequest = function(opt_data) {
-  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+  jspb.Message.initialize(this, opt_data, 0, -1, proto.SignUpRequest.repeatedFields_, null);
 };
 goog.inherits(proto.SignUpRequest, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
@@ -497,6 +497,13 @@ proto.SignInResponse.prototype.setToken = function(value) {
 
 
 
+/**
+ * List of repeated fields within this message type.
+ * @private {!Array<number>}
+ * @const
+ */
+proto.SignUpRequest.repeatedFields_ = [7];
+
 
 
 if (jspb.Message.GENERATE_TO_OBJECT) {
@@ -533,7 +540,8 @@ proto.SignUpRequest.toObject = function(includeInstance, msg) {
     nickname: jspb.Message.getFieldWithDefault(msg, 3, ""),
     gender: jspb.Message.getFieldWithDefault(msg, 4, 0),
     avatar: jspb.Message.getFieldWithDefault(msg, 5, ""),
-    birthday: jspb.Message.getFieldWithDefault(msg, 6, "")
+    birthday: jspb.Message.getFieldWithDefault(msg, 6, ""),
+    interesthashtagsList: (f = jspb.Message.getRepeatedField(msg, 7)) == null ? undefined : f
   };
 
   if (includeInstance) {
@@ -593,6 +601,10 @@ proto.SignUpRequest.deserializeBinaryFromReader = function(msg, reader) {
     case 6:
       var value = /** @type {string} */ (reader.readString());
       msg.setBirthday(value);
+      break;
+    case 7:
+      var value = /** @type {string} */ (reader.readString());
+      msg.addInteresthashtags(value);
       break;
     default:
       reader.skipField();
@@ -662,6 +674,13 @@ proto.SignUpRequest.serializeBinaryToWriter = function(message, writer) {
   if (f.length > 0) {
     writer.writeString(
       6,
+      f
+    );
+  }
+  f = message.getInteresthashtagsList();
+  if (f.length > 0) {
+    writer.writeRepeatedString(
+      7,
       f
     );
   }
@@ -781,6 +800,43 @@ proto.SignUpRequest.prototype.getBirthday = function() {
  */
 proto.SignUpRequest.prototype.setBirthday = function(value) {
   return jspb.Message.setProto3StringField(this, 6, value);
+};
+
+
+/**
+ * repeated string interestHashTags = 7;
+ * @return {!Array<string>}
+ */
+proto.SignUpRequest.prototype.getInteresthashtagsList = function() {
+  return /** @type {!Array<string>} */ (jspb.Message.getRepeatedField(this, 7));
+};
+
+
+/**
+ * @param {!Array<string>} value
+ * @return {!proto.SignUpRequest} returns this
+ */
+proto.SignUpRequest.prototype.setInteresthashtagsList = function(value) {
+  return jspb.Message.setField(this, 7, value || []);
+};
+
+
+/**
+ * @param {string} value
+ * @param {number=} opt_index
+ * @return {!proto.SignUpRequest} returns this
+ */
+proto.SignUpRequest.prototype.addInteresthashtags = function(value, opt_index) {
+  return jspb.Message.addToRepeatedField(this, 7, value, opt_index);
+};
+
+
+/**
+ * Clears the list making it empty but non-null.
+ * @return {!proto.SignUpRequest} returns this
+ */
+proto.SignUpRequest.prototype.clearInteresthashtagsList = function() {
+  return this.setInteresthashtagsList([]);
 };
 
 

--- a/proto/src/UserProtocol.proto
+++ b/proto/src/UserProtocol.proto
@@ -40,6 +40,7 @@ message SignUpRequest {
     Gender gender = 4;
     string avatar = 5;
     string birthday = 6;
+    repeated string interestHashTags = 7;
 }
 
 message SignUpResponse {

--- a/server/src/main/java/com/block/server/_generated/proto/userservice/SignUpRequest.java
+++ b/server/src/main/java/com/block/server/_generated/proto/userservice/SignUpRequest.java
@@ -22,6 +22,7 @@ private static final long serialVersionUID = 0L;
     gender_ = 0;
     avatar_ = "";
     birthday_ = "";
+    interestHashTags_ = com.google.protobuf.LazyStringArrayList.EMPTY;
   }
 
   @java.lang.Override
@@ -44,6 +45,7 @@ private static final long serialVersionUID = 0L;
     if (extensionRegistry == null) {
       throw new java.lang.NullPointerException();
     }
+    int mutable_bitField0_ = 0;
     com.google.protobuf.UnknownFieldSet.Builder unknownFields =
         com.google.protobuf.UnknownFieldSet.newBuilder();
     try {
@@ -90,6 +92,15 @@ private static final long serialVersionUID = 0L;
             birthday_ = s;
             break;
           }
+          case 58: {
+            java.lang.String s = input.readStringRequireUtf8();
+            if (!((mutable_bitField0_ & 0x00000001) != 0)) {
+              interestHashTags_ = new com.google.protobuf.LazyStringArrayList();
+              mutable_bitField0_ |= 0x00000001;
+            }
+            interestHashTags_.add(s);
+            break;
+          }
           default: {
             if (!parseUnknownField(
                 input, unknownFields, extensionRegistry, tag)) {
@@ -105,6 +116,9 @@ private static final long serialVersionUID = 0L;
       throw new com.google.protobuf.InvalidProtocolBufferException(
           e).setUnfinishedMessage(this);
     } finally {
+      if (((mutable_bitField0_ & 0x00000001) != 0)) {
+        interestHashTags_ = interestHashTags_.getUnmodifiableView();
+      }
       this.unknownFields = unknownFields.build();
       makeExtensionsImmutable();
     }
@@ -439,6 +453,41 @@ private static final long serialVersionUID = 0L;
     }
   }
 
+  public static final int INTERESTHASHTAGS_FIELD_NUMBER = 7;
+  private com.google.protobuf.LazyStringList interestHashTags_;
+  /**
+   * <code>repeated string interestHashTags = 7;</code>
+   * @return A list containing the interestHashTags.
+   */
+  public com.google.protobuf.ProtocolStringList
+      getInterestHashTagsList() {
+    return interestHashTags_;
+  }
+  /**
+   * <code>repeated string interestHashTags = 7;</code>
+   * @return The count of interestHashTags.
+   */
+  public int getInterestHashTagsCount() {
+    return interestHashTags_.size();
+  }
+  /**
+   * <code>repeated string interestHashTags = 7;</code>
+   * @param index The index of the element to return.
+   * @return The interestHashTags at the given index.
+   */
+  public java.lang.String getInterestHashTags(int index) {
+    return interestHashTags_.get(index);
+  }
+  /**
+   * <code>repeated string interestHashTags = 7;</code>
+   * @param index The index of the value to return.
+   * @return The bytes of the interestHashTags at the given index.
+   */
+  public com.google.protobuf.ByteString
+      getInterestHashTagsBytes(int index) {
+    return interestHashTags_.getByteString(index);
+  }
+
   private byte memoizedIsInitialized = -1;
   @java.lang.Override
   public final boolean isInitialized() {
@@ -471,6 +520,9 @@ private static final long serialVersionUID = 0L;
     if (!getBirthdayBytes().isEmpty()) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 6, birthday_);
     }
+    for (int i = 0; i < interestHashTags_.size(); i++) {
+      com.google.protobuf.GeneratedMessageV3.writeString(output, 7, interestHashTags_.getRaw(i));
+    }
     unknownFields.writeTo(output);
   }
 
@@ -499,6 +551,14 @@ private static final long serialVersionUID = 0L;
     if (!getBirthdayBytes().isEmpty()) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(6, birthday_);
     }
+    {
+      int dataSize = 0;
+      for (int i = 0; i < interestHashTags_.size(); i++) {
+        dataSize += computeStringSizeNoTag(interestHashTags_.getRaw(i));
+      }
+      size += dataSize;
+      size += 1 * getInterestHashTagsList().size();
+    }
     size += unknownFields.getSerializedSize();
     memoizedSize = size;
     return size;
@@ -525,6 +585,8 @@ private static final long serialVersionUID = 0L;
         .equals(other.getAvatar())) return false;
     if (!getBirthday()
         .equals(other.getBirthday())) return false;
+    if (!getInterestHashTagsList()
+        .equals(other.getInterestHashTagsList())) return false;
     if (!unknownFields.equals(other.unknownFields)) return false;
     return true;
   }
@@ -548,6 +610,10 @@ private static final long serialVersionUID = 0L;
     hash = (53 * hash) + getAvatar().hashCode();
     hash = (37 * hash) + BIRTHDAY_FIELD_NUMBER;
     hash = (53 * hash) + getBirthday().hashCode();
+    if (getInterestHashTagsCount() > 0) {
+      hash = (37 * hash) + INTERESTHASHTAGS_FIELD_NUMBER;
+      hash = (53 * hash) + getInterestHashTagsList().hashCode();
+    }
     hash = (29 * hash) + unknownFields.hashCode();
     memoizedHashCode = hash;
     return hash;
@@ -693,6 +759,8 @@ private static final long serialVersionUID = 0L;
 
       birthday_ = "";
 
+      interestHashTags_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      bitField0_ = (bitField0_ & ~0x00000001);
       return this;
     }
 
@@ -719,12 +787,18 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public com.block.server._generated.proto.userservice.SignUpRequest buildPartial() {
       com.block.server._generated.proto.userservice.SignUpRequest result = new com.block.server._generated.proto.userservice.SignUpRequest(this);
+      int from_bitField0_ = bitField0_;
       result.email_ = email_;
       result.password_ = password_;
       result.nickname_ = nickname_;
       result.gender_ = gender_;
       result.avatar_ = avatar_;
       result.birthday_ = birthday_;
+      if (((bitField0_ & 0x00000001) != 0)) {
+        interestHashTags_ = interestHashTags_.getUnmodifiableView();
+        bitField0_ = (bitField0_ & ~0x00000001);
+      }
+      result.interestHashTags_ = interestHashTags_;
       onBuilt();
       return result;
     }
@@ -796,6 +870,16 @@ private static final long serialVersionUID = 0L;
         birthday_ = other.birthday_;
         onChanged();
       }
+      if (!other.interestHashTags_.isEmpty()) {
+        if (interestHashTags_.isEmpty()) {
+          interestHashTags_ = other.interestHashTags_;
+          bitField0_ = (bitField0_ & ~0x00000001);
+        } else {
+          ensureInterestHashTagsIsMutable();
+          interestHashTags_.addAll(other.interestHashTags_);
+        }
+        onChanged();
+      }
       this.mergeUnknownFields(other.unknownFields);
       onChanged();
       return this;
@@ -824,6 +908,7 @@ private static final long serialVersionUID = 0L;
       }
       return this;
     }
+    private int bitField0_;
 
     private java.lang.Object email_ = "";
     /**
@@ -1255,6 +1340,116 @@ private static final long serialVersionUID = 0L;
   checkByteStringIsUtf8(value);
       
       birthday_ = value;
+      onChanged();
+      return this;
+    }
+
+    private com.google.protobuf.LazyStringList interestHashTags_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+    private void ensureInterestHashTagsIsMutable() {
+      if (!((bitField0_ & 0x00000001) != 0)) {
+        interestHashTags_ = new com.google.protobuf.LazyStringArrayList(interestHashTags_);
+        bitField0_ |= 0x00000001;
+       }
+    }
+    /**
+     * <code>repeated string interestHashTags = 7;</code>
+     * @return A list containing the interestHashTags.
+     */
+    public com.google.protobuf.ProtocolStringList
+        getInterestHashTagsList() {
+      return interestHashTags_.getUnmodifiableView();
+    }
+    /**
+     * <code>repeated string interestHashTags = 7;</code>
+     * @return The count of interestHashTags.
+     */
+    public int getInterestHashTagsCount() {
+      return interestHashTags_.size();
+    }
+    /**
+     * <code>repeated string interestHashTags = 7;</code>
+     * @param index The index of the element to return.
+     * @return The interestHashTags at the given index.
+     */
+    public java.lang.String getInterestHashTags(int index) {
+      return interestHashTags_.get(index);
+    }
+    /**
+     * <code>repeated string interestHashTags = 7;</code>
+     * @param index The index of the value to return.
+     * @return The bytes of the interestHashTags at the given index.
+     */
+    public com.google.protobuf.ByteString
+        getInterestHashTagsBytes(int index) {
+      return interestHashTags_.getByteString(index);
+    }
+    /**
+     * <code>repeated string interestHashTags = 7;</code>
+     * @param index The index to set the value at.
+     * @param value The interestHashTags to set.
+     * @return This builder for chaining.
+     */
+    public Builder setInterestHashTags(
+        int index, java.lang.String value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureInterestHashTagsIsMutable();
+      interestHashTags_.set(index, value);
+      onChanged();
+      return this;
+    }
+    /**
+     * <code>repeated string interestHashTags = 7;</code>
+     * @param value The interestHashTags to add.
+     * @return This builder for chaining.
+     */
+    public Builder addInterestHashTags(
+        java.lang.String value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureInterestHashTagsIsMutable();
+      interestHashTags_.add(value);
+      onChanged();
+      return this;
+    }
+    /**
+     * <code>repeated string interestHashTags = 7;</code>
+     * @param values The interestHashTags to add.
+     * @return This builder for chaining.
+     */
+    public Builder addAllInterestHashTags(
+        java.lang.Iterable<java.lang.String> values) {
+      ensureInterestHashTagsIsMutable();
+      com.google.protobuf.AbstractMessageLite.Builder.addAll(
+          values, interestHashTags_);
+      onChanged();
+      return this;
+    }
+    /**
+     * <code>repeated string interestHashTags = 7;</code>
+     * @return This builder for chaining.
+     */
+    public Builder clearInterestHashTags() {
+      interestHashTags_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      bitField0_ = (bitField0_ & ~0x00000001);
+      onChanged();
+      return this;
+    }
+    /**
+     * <code>repeated string interestHashTags = 7;</code>
+     * @param value The bytes of the interestHashTags to add.
+     * @return This builder for chaining.
+     */
+    public Builder addInterestHashTagsBytes(
+        com.google.protobuf.ByteString value) {
+      if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+      ensureInterestHashTagsIsMutable();
+      interestHashTags_.add(value);
       onChanged();
       return this;
     }

--- a/server/src/main/java/com/block/server/_generated/proto/userservice/SignUpRequestOrBuilder.java
+++ b/server/src/main/java/com/block/server/_generated/proto/userservice/SignUpRequestOrBuilder.java
@@ -77,4 +77,29 @@ public interface SignUpRequestOrBuilder extends
    */
   com.google.protobuf.ByteString
       getBirthdayBytes();
+
+  /**
+   * <code>repeated string interestHashTags = 7;</code>
+   * @return A list containing the interestHashTags.
+   */
+  java.util.List<java.lang.String>
+      getInterestHashTagsList();
+  /**
+   * <code>repeated string interestHashTags = 7;</code>
+   * @return The count of interestHashTags.
+   */
+  int getInterestHashTagsCount();
+  /**
+   * <code>repeated string interestHashTags = 7;</code>
+   * @param index The index of the element to return.
+   * @return The interestHashTags at the given index.
+   */
+  java.lang.String getInterestHashTags(int index);
+  /**
+   * <code>repeated string interestHashTags = 7;</code>
+   * @param index The index of the value to return.
+   * @return The bytes of the interestHashTags at the given index.
+   */
+  com.google.protobuf.ByteString
+      getInterestHashTagsBytes(int index);
 }

--- a/server/src/main/java/com/block/server/_generated/proto/userservice/UserProtocolOuterClass.java
+++ b/server/src/main/java/com/block/server/_generated/proto/userservice/UserProtocolOuterClass.java
@@ -49,21 +49,21 @@ public final class UserProtocolOuterClass {
       "se.SignInStatus\022\020\n\010nickname\030\002 \001(\t\022\022\n\npro" +
       "fileUrl\030\003 \001(\t\022\r\n\005token\030\004 \001(\t\"S\n\014SignInSt" +
       "atus\022\013\n\007SUCCESS\020\000\022\016\n\nNO_ACCOUNT\020\001\022\022\n\016WRO" +
-      "NG_PASSWORD\020\002\022\022\n\016INTERNAL_ERROR\020\003\"\253\001\n\rSi" +
+      "NG_PASSWORD\020\002\022\022\n\016INTERNAL_ERROR\020\003\"\305\001\n\rSi" +
       "gnUpRequest\022\r\n\005email\030\001 \001(\t\022\020\n\010password\030\002" +
       " \001(\t\022\020\n\010nickname\030\003 \001(\t\022%\n\006gender\030\004 \001(\0162\025" +
       ".SignUpRequest.Gender\022\016\n\006avatar\030\005 \001(\t\022\020\n" +
-      "\010birthday\030\006 \001(\t\"\036\n\006Gender\022\010\n\004MALE\020\000\022\n\n\006F" +
-      "EMALE\020\001\"\274\001\n\016SignUpResponse\022,\n\006status\030\001 \001" +
-      "(\0162\034.SignUpResponse.SignUpStatus\022\020\n\010nick" +
-      "name\030\002 \001(\t\022\022\n\nprofileUrl\030\003 \001(\t\"V\n\014SignUp" +
-      "Status\022\013\n\007SUCCESS\020\000\022\022\n\016ACCOUNT_EXISTS\020\001\022" +
-      "\021\n\rINVALID_INPUT\020\002\022\022\n\016INTERNAL_ERROR\020\0032h" +
-      "\n\014UserProtocol\022+\n\006SignIn\022\016.SignInRequest" +
-      "\032\017.SignInResponse\"\000\022+\n\006SignUp\022\016.SignUpRe" +
-      "quest\032\017.SignUpResponse\"\000B1\n-com.block.se" +
-      "rver._generated.proto.userserviceP\001b\006pro" +
-      "to3"
+      "\010birthday\030\006 \001(\t\022\030\n\020interestHashTags\030\007 \003(" +
+      "\t\"\036\n\006Gender\022\010\n\004MALE\020\000\022\n\n\006FEMALE\020\001\"\274\001\n\016Si" +
+      "gnUpResponse\022,\n\006status\030\001 \001(\0162\034.SignUpRes" +
+      "ponse.SignUpStatus\022\020\n\010nickname\030\002 \001(\t\022\022\n\n" +
+      "profileUrl\030\003 \001(\t\"V\n\014SignUpStatus\022\013\n\007SUCC" +
+      "ESS\020\000\022\022\n\016ACCOUNT_EXISTS\020\001\022\021\n\rINVALID_INP" +
+      "UT\020\002\022\022\n\016INTERNAL_ERROR\020\0032h\n\014UserProtocol" +
+      "\022+\n\006SignIn\022\016.SignInRequest\032\017.SignInRespo" +
+      "nse\"\000\022+\n\006SignUp\022\016.SignUpRequest\032\017.SignUp" +
+      "Response\"\000B1\n-com.block.server._generate" +
+      "d.proto.userserviceP\001b\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -86,7 +86,7 @@ public final class UserProtocolOuterClass {
     internal_static_SignUpRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_SignUpRequest_descriptor,
-        new java.lang.String[] { "Email", "Password", "Nickname", "Gender", "Avatar", "Birthday", });
+        new java.lang.String[] { "Email", "Password", "Nickname", "Gender", "Avatar", "Birthday", "InterestHashTags", });
     internal_static_SignUpResponse_descriptor =
       getDescriptor().getMessageTypes().get(3);
     internal_static_SignUpResponse_fieldAccessorTable = new

--- a/server/src/main/java/com/block/server/domain/HashTag.java
+++ b/server/src/main/java/com/block/server/domain/HashTag.java
@@ -1,0 +1,28 @@
+package com.block.server.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "HASHTAG")
+public class HashTag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private String tagName;
+
+    @Builder
+    public HashTag(String tagName) {
+        this.tagName = tagName;
+    }
+}

--- a/server/src/main/java/com/block/server/domain/User.java
+++ b/server/src/main/java/com/block/server/domain/User.java
@@ -11,6 +11,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import javax.persistence.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @NoArgsConstructor
 @Getter
@@ -54,8 +55,12 @@ public class User {
     @Column
     private String roles;
 
+    @OneToMany
+    @JoinColumn(name="HASHTAG_ID")
+    private List<HashTag> interestHashTags;
+
     @Builder
-    public User(String email, String password, String nickname, String profile, LocalDate birthday, SignUpRequest.Gender gender, String social, String roles) {
+    public User(String email, String password, String nickname, String profile, LocalDate birthday, SignUpRequest.Gender gender, String social, String roles, List<HashTag> interestHashTags) {
         this.email = email;
         this.password = password;
         this.nickname = nickname;
@@ -64,5 +69,6 @@ public class User {
         this.gender = gender;
         this.social = social;
         this.roles = roles;
+        this.interestHashTags = interestHashTags;
     }
 }

--- a/server/src/main/java/com/block/server/domain/repository/HashTagRepository.java
+++ b/server/src/main/java/com/block/server/domain/repository/HashTagRepository.java
@@ -1,0 +1,13 @@
+package com.block.server.domain.repository;
+
+import com.block.server.domain.HashTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface HashTagRepository extends JpaRepository<HashTag, Long> {
+
+    Optional<HashTag> findByTagName(String tagName);
+}

--- a/server/src/main/java/com/block/server/service/HashTagService.java
+++ b/server/src/main/java/com/block/server/service/HashTagService.java
@@ -1,0 +1,7 @@
+package com.block.server.service;
+
+import com.block.server.domain.HashTag;
+
+public interface HashTagService {
+    HashTag getOrCreateTag(String tagName);
+}

--- a/server/src/main/java/com/block/server/service/HashTagServiceImpl.java
+++ b/server/src/main/java/com/block/server/service/HashTagServiceImpl.java
@@ -1,0 +1,27 @@
+package com.block.server.service;
+
+import com.block.server.domain.HashTag;
+import com.block.server.domain.repository.HashTagRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class HashTagServiceImpl implements HashTagService {
+
+    private final HashTagRepository hashTagRepository;
+
+    public HashTag getOrCreateTag(String tagName) {
+        var tag = hashTagRepository.findByTagName(tagName);
+        if (tag.isPresent()) {
+            return tag.get();
+        }
+
+        var newTag = HashTag.builder()
+                .tagName(tagName)
+                .build();
+        hashTagRepository.save(newTag);
+
+        return newTag;
+    }
+}

--- a/server/src/main/java/com/block/server/service/UserServiceImpl.java
+++ b/server/src/main/java/com/block/server/service/UserServiceImpl.java
@@ -18,6 +18,7 @@ import io.github.majusko.grpc.jwt.service.dto.JwtData;
 
 import java.time.LocalDate;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
@@ -29,6 +30,7 @@ public class UserServiceImpl implements UserService {
     private final PasswordEncoder passwordEncoder;
     private final JwtService jwtService;
 
+    private final HashTagService hashTagService;
 
     @Transactional
     public SignInResponse signIn(SignInRequest signInRequest)  {
@@ -78,6 +80,9 @@ public class UserServiceImpl implements UserService {
                     .build();
         }
 
+        var hashTags = request.getInterestHashTagsList().stream()
+                .map(x -> hashTagService.getOrCreateTag(x)).collect(Collectors.toList());
+
         var encodedPassword = passwordEncoder.encode(request.getPassword());
         var profileUrl = "http://example.com/image/" + request.getAvatar();
         var user = User.builder()
@@ -89,6 +94,7 @@ public class UserServiceImpl implements UserService {
                 .profile(profileUrl)
                 .social("")                 // temp
                 .roles(Roles.USER)          // default role
+                .interestHashTags(hashTags)
                 .build();
 
         var savedUser = userRepository.save(user);

--- a/server/src/test/java/com/block/server/helper/TestUser.java
+++ b/server/src/test/java/com/block/server/helper/TestUser.java
@@ -1,12 +1,16 @@
 package com.block.server.helper;
 
 import com.block.server._generated.proto.userservice.SignUpRequest;
+import com.block.server.domain.HashTag;
 import com.block.server.domain.User;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @NoArgsConstructor
@@ -20,6 +24,7 @@ public class TestUser {
     private SignUpRequest.Gender gender;
     private String social;
     private String role;
+    private List<String> interestHashTags;
 
     public static TestUser U1() {
         return TestUser.builder()
@@ -30,11 +35,12 @@ public class TestUser {
                 .gender(SignUpRequest.Gender.MALE)
                 .nickname("helloworld")
                 .role("test-role")
+                .interestHashTags(Arrays.asList("test1", "test2"))
                 .build();
     }
 
     @Builder
-    public TestUser(String email, String rawPassword, String nickname, String avatar, String birthdayStr, SignUpRequest.Gender gender, String social, String role) {
+    public TestUser(String email, String rawPassword, String nickname, String avatar, String birthdayStr, SignUpRequest.Gender gender, String social, String role, List<String> interestHashTags) {
         this.email = email;
         this.rawPassword = rawPassword;
         this.nickname = nickname;
@@ -43,6 +49,7 @@ public class TestUser {
         this.gender = gender;
         this.social = social;
         this.role = role;
+        this.interestHashTags = interestHashTags;
     }
 
     public User toUser() {
@@ -58,6 +65,9 @@ public class TestUser {
                 .gender(gender)
                 .nickname(nickname)
                 .roles(role)
+                .interestHashTags(interestHashTags.stream()
+                        .map(x -> HashTag.builder().tagName(x).build())
+                        .collect(Collectors.toList()))
                 .build();
     }
 }

--- a/server/src/test/java/com/block/server/service/hashtag/HashTagServiceTest.java
+++ b/server/src/test/java/com/block/server/service/hashtag/HashTagServiceTest.java
@@ -1,0 +1,71 @@
+package com.block.server.service.hashtag;
+
+import com.block.server.domain.HashTag;
+import com.block.server.domain.repository.HashTagRepository;
+import com.block.server.service.HashTagServiceImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.client.ExpectedCount.times;
+
+@ExtendWith(MockitoExtension.class)
+public class HashTagServiceTest {
+
+    @Mock
+    private HashTagRepository hashTagRepository;
+
+    @InjectMocks
+    private HashTagServiceImpl hashTagService;
+
+    @Test
+    @DisplayName("getOrCreate 시 새 태그를 repo에 저장해야함")
+    public void getOrCreate_should_create_new_tag() throws Exception {
+
+        var expectedName = "newTagResult";
+        var newHashTag = HashTag.builder()
+                .tagName(expectedName)
+                .build();
+
+        doReturn(newHashTag)
+                .when(hashTagRepository)
+                .save(any());
+        doReturn(Optional.empty())
+                .when(hashTagRepository)
+                .findByTagName(any());
+
+        var newTag = hashTagService.getOrCreateTag(expectedName);
+
+        ArgumentCaptor<HashTag> hashTagArgumentCaptor = ArgumentCaptor.forClass(HashTag.class);
+        verify(hashTagRepository).save(hashTagArgumentCaptor.capture());
+
+        assertEquals(expectedName, hashTagArgumentCaptor.getValue().getTagName());
+    }
+
+    @Test
+    @DisplayName("getOrCreate 시 존재하는 tag를 return 해야 함")
+    public void getOrCreate_should_return_existing_tag() throws Exception {
+
+        var expectedName = "newTagResult";
+        var newHashTag = HashTag.builder()
+                .tagName(expectedName)
+                .build();
+
+        doReturn(Optional.ofNullable(newHashTag))
+                .when(hashTagRepository)
+                .findByTagName(any());
+
+        var newTag = hashTagService.getOrCreateTag(expectedName);
+
+        verify(hashTagRepository, never()).save(any());
+    }
+}


### PR DESCRIPTION
### 체크리스트 

- [x] 커밋 메세지 포맷 (feature, chore, bugfix, BLOCK-x, BE, FE)
  - [{BE|FE}] {feat-BLOCK-x|chore|bugfix-BLOCK-x}: {message}
    - ex. `[BE] feat-BLOCK-1: 회원가입 API 구현`
    - ex. `[FE] chore: 패키지 dependancy update`
    - ex. `[FE] bugfix-BLOCK-1: 생일 date 정보 버그 해결`

- [x] 테스트 구현 했는가 (for bug fixes / features)



### 작업 내용 요약 (Before & After)

- SignUpRequest에 InterestHashTags: string[] 추가
- HashTag entity 추가
- SignUp 시에 hashTag 없으면 생성하도록 구현


### 기타 내용

- @saegeullee SignUpRequest 구현 괜찮은지 의견 부탁드려요!
